### PR TITLE
Rename libdash library to avoid name collision in dune

### DIFF
--- a/dune
+++ b/dune
@@ -6,6 +6,7 @@
            builtins.h nodes.h syntax.h token.h token_vars.h
            )
   (action
+    (setenv CC "%{cc}"
     (bash
     "\
      \n set -e\
@@ -17,7 +18,7 @@
      \n cp lib/libdash.a libdash.a\
      \n cp lib/dlldash.so dlldash.so\
      \n cp src/{builtins,nodes,syntax,token,token_vars}.h .\
-     \n")))
+     \n"))))
 
 (subdir src
   (rule

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -3,8 +3,10 @@
  (public_names shell_to_json json_to_shell)
  (modules shell_to_json json_to_shell ast_json)
  (modes (native exe))
- (foreign_archives ../dash)
  (libraries libdash yojson atdgen))
+
+(rule (copy ../dlldash.so dlldash_native.so))
+(rule (copy ../libdash.a libdash_native.a))
 
 (library
   (name libdash)
@@ -12,9 +14,10 @@
   (modes native)
   (modules (:standard \ json_to_shell shell_to_json ast_json))
   (libraries ctypes ctypes.foreign)
+  (foreign_archives dash_native)
   (ctypes
     (external_library_name dash)
-    (build_flags_resolver (vendored (c_flags :standard) (c_library_flags :standard)))
+    (build_flags_resolver vendored)
     (deps (glob_files ../src/*.h) ../src/builtins.h ../src/nodes.h ../src/syntax.h ../src/token.h ../src/token_vars.h)
     (headers (preamble
               "\


### PR DESCRIPTION
Applying a fix from @emillon in https://github.com/ocaml/dune/issues/9773---this seems to produce a `shell_to_json` and `json_to_shell` that function _and_ I'm able to link against the library. 🎉 